### PR TITLE
Added ODS as format choice

### DIFF
--- a/lmgtfy/constants.py
+++ b/lmgtfy/constants.py
@@ -6,6 +6,7 @@ FORMAT_CHOICES = (
     'json',
     'shp',
     'xml',
+    'ods',
     #'pdf',
     #'zip',
     #'doc',


### PR DESCRIPTION
ODS (OpenDocument Spreadsheet file format) is used a lot by the Dutch government, and possibly many others, so it would be good to have it added as a default format choice